### PR TITLE
Fix Broken Slack-Bot Tutorial Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It uses NASA's most API [APOD].
 
 ### Development
 
-While making it I've used Slack's tutorial for [making bots with Ruby].
+While making it I've used Slack's tutorial for [making bots with Ruby](https://github.com/slack-ruby/slack-ruby-bot/blob/master/TUTORIAL.md "Slack-Ruby-Bot Tutorial").
 
 ### Runing a bot locally
 


### PR DESCRIPTION
Needed a reformat of markdown.
Found the original source and gave it the correct markdown.